### PR TITLE
Fix #3: package the kotlin gradle model

### DIFF
--- a/kotlin-eclipse-gradle-model/pom.xml
+++ b/kotlin-eclipse-gradle-model/pom.xml
@@ -16,7 +16,7 @@
 
     <build>
         <sourceDirectory>src</sourceDirectory>
-
+		<finalName>kotlin-eclipse-gradle-model</finalName>
         <plugins>
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
@@ -32,6 +32,29 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+            	<groupId>org.apache.maven.plugins</groupId>
+            	<artifactId>maven-jar-plugin</artifactId>
+            	<version>3.2.0</version>
+            	<executions>
+            		<execution>
+            			<id>kotlin-jar</id>
+            			<goals>
+            				<goal>jar</goal>
+            			</goals>
+            			<phase>prepare-package</phase>
+            			<configuration>
+            				<outputDirectory>${project.basedir}/lib</outputDirectory>
+            				<includes>
+            					<include>**/*.class</include>
+            				</includes>
+            			</configuration>
+            		</execution>
+            	</executions>
+            	<configuration>
+            		<excludes>**/*</excludes>
+            	</configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
The maven build was not packaging the compiled content as a eclipse
bundle which can be looked up later for using with the kotlin init
script. With the current change the compiled and packaged as a jar
 and included in the bundle inside the lib directory.