### PR TITLE
Fix #11: Fixed NPE when inspecting inside lambda

### DIFF
--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/utils/DebugUtils.java
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/utils/DebugUtils.java
@@ -1,5 +1,7 @@
 package org.jetbrains.kotlin.core.utils;
 
+import java.util.Optional;
+
 import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.model.IStackFrame;
 import org.eclipse.debug.core.model.IVariable;
@@ -19,7 +21,7 @@ public class DebugUtils {
     public static Boolean hasKotlinSource(IStackFrame frame) throws DebugException {
         if (frame instanceof IJavaStackFrame) {
             IJavaStackFrame javaFrame = (IJavaStackFrame) frame;
-            return javaFrame.getSourceName().endsWith(".kt");
+            return Optional.ofNullable(javaFrame.getSourceName()).map(s -> s.endsWith(".kt")).orElse(false);
         } else {
             return false;
         }


### PR DESCRIPTION
When inspecting lambda frames the source name is null.
The fix handles that by checking null before checking for kt extension.